### PR TITLE
Add architecture distinction with ansible_architecture for debian-like dists

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -35,12 +35,12 @@ _docker_ce_conflicting_packages:
     - runc
 
 _docker_ce_arches:
-  - default: amd64
-  - x86_64: amd64
-  - aarch64: arm64
-  - armv7l: armhf
-  - s390x: s390x
-  - ppc64le: ppc64le
+  default: amd64
+  x86_64: amd64
+  aarch64: arm64
+  armv7l: armhf
+  s390x: s390x
+  ppc64le: ppc64le
 
 docker_ce_conflicting_packages: "{{ _docker_ce_conflicting_packages[ansible_distribution] }}"
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -34,11 +34,21 @@ _docker_ce_conflicting_packages:
     - containerd
     - runc
 
+_docker_ce_arches:
+  - default: amd64
+  - x86_64: amd64
+  - aarch64: arm64
+  - armv7l: armhf
+  - s390x: s390x
+  - ppc64le: ppc64le
+
 docker_ce_conflicting_packages: "{{ _docker_ce_conflicting_packages[ansible_distribution] }}"
 
 docker_ce_apt_key_url: "https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg"
 
-docker_ce_apt_repository_repo: "deb [arch=amd64] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
+docker_ce_apt_repository_arch: "{{ _docker_ce_arches[ansible_architecture] | default(_docker_ce_arches['default']) }}"
+
+docker_ce_apt_repository_repo: "deb [arch={{ docker_ce_apt_repository_arch }}] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
 
 docker_ce_yum_repositories:
   - name: docker-ce-stable


### PR DESCRIPTION
Signed-off-by: Fabien ZARIFIAN <fabien.zarifian@nuevolia.fr>

---
name: Pull request
about: Describe the proposed change

---

**Describe the change**
When installing on non amd64 on Debian-like distribution, docker installation should not work.

From my infrastructure :

- **Return of dpkg --print-architecture**

```
testhost$ ansible all -m command -a "dpkg --print-architecture"
test-amd64-ansible | CHANGED | rc=0 >>
amd64

test-arm64-ansible | CHANGED | rc=0 >>
arm64

test-armhf-ansible | CHANGED | rc=0 >>
armhf
```

- **ansible_architecture fact**

```
testhost$ ansible all -m setup -a filter=ansible_architecture
test-amd64-ansible | SUCCESS => {
    "ansible_facts": {
        "ansible_architecture": "x86_64"
    },
    "changed": false
}
test-arm64-ansible | SUCCESS => {
    "ansible_facts": {
        "ansible_architecture": "aarch64"
    },
    "changed": false
}
test-armhf-ansible | SUCCESS => {
    "ansible_facts": {
        "ansible_architecture": "armv7l"
    },
    "changed": false
}
Playbook run took 0 days, 0 hours, 0 minutes, 9 seconds
```

**Testing**
No idea how to test this with travis-ci