### PR TITLE
Updated vars to support RedHat as an installation target

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,14 +1,8 @@
 ---
 # vars file for docker_ce
 _docker_ce_conflicting_packages:
-  Aloine:
+  Alpine:
     - docker
-  Debian:
-    - docker
-    - docker-engine
-    - docker.io
-    - containerd
-    - runc
   CentOS:
     - docker
     - docker-client
@@ -18,6 +12,12 @@ _docker_ce_conflicting_packages:
     - docker-latest-logrotate
     - docker-logrotate
     - docker-engine
+  Debian:
+    - docker
+    - docker-engine
+    - docker.io
+    - containerd
+    - runc
   Fedora:
     - docker
     - docker-client
@@ -26,6 +26,12 @@ _docker_ce_conflicting_packages:
     - docker-latest
     - docker-latest-logrotate
     - docker-logrotate
+    - docker-selinux
+    - docker-engine-selinux
+    - docker-engine
+  RedHat:
+    - docker
+    - docker-common
     - docker-selinux
     - docker-engine-selinux
     - docker-engine
@@ -46,20 +52,25 @@ _docker_ce_arches:
 
 docker_ce_conflicting_packages: "{{ _docker_ce_conflicting_packages[ansible_distribution] }}"
 
+# Debian / Ubuntu repo
 docker_ce_apt_key_url: "https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg"
-
 docker_ce_apt_repository_arch: "{{ _docker_ce_arches[ansible_architecture] | default(_docker_ce_arches['default']) }}"
-
 docker_ce_apt_repository_repo: "deb [arch={{ docker_ce_apt_repository_arch }}] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
 
+# CentOs / Fedora / RedHat repo
+
+# RedHat is not availabe as a distro on http://download.docker.com/linux, replace it with CentOs
+_docker_ce_yum_distribution: "{% if ansible_distribution == 'RedHat' %}CentOS{% else %}{{ ansible_distribution }}{% endif %}"
+_docker_ce_yum_releasever: "{% if ansible_distribution in ['CentOS','RedHat'] %}{{ ansible_distribution_major_version }}{% else %}$releasever{% endif %}"
 docker_ce_yum_repositories:
   - name: docker-ce-stable
     description: "Docker CE Stable - $basearch"
-    baseurl: "https://download.docker.com/linux/{{ ansible_distribution | lower }}/$releasever/$basearch/stable"
-    gpgkey: "https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg"
+    baseurl: "https://download.docker.com/linux/{{ _docker_ce_yum_distribution | lower }}/{{ _docker_ce_yum_releasever }}/$basearch/stable"
+    gpgkey: "https://download.docker.com/linux/{{ _docker_ce_yum_distribution | lower }}/gpg"
 
 docker_ce_pip_packages:
   - docker
+  - docker-compose
 
 docker_ce_packages:
   - docker-ce


### PR DESCRIPTION
---
name: Pull request
about: Added RedHat as a installation target

---

**Describe the change**
Updated the vars/main.yml so this role can be used on Rhel 7. Because Docker does not offer a specific download for RedHat distro's the CentOs repo is used as a source.

**Testing**
Ran this role on a RHEL7 server from Azure
