### PR TITLE
Update role to support Fedora 33

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -11,7 +11,7 @@ on:
       - '*'
   pull_request:
   schedule:
-    - cron: '4 4 4 * *'
+    - cron: '7 4 4 * *'
 
 jobs:
   lint:
@@ -39,6 +39,8 @@ jobs:
             tag: "latest"
           - image: "fedora"
             tag: "32"
+          - image: "fedora"
+            tag: "latest"
           - image: "ubuntu"
             tag: "latest"
           - image: "ubuntu"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,6 +22,8 @@ molecule:
         tag: "latest"
       - image: "fedora"
         tag: "32"
+      - image: "fedora"
+        tag: "latest"
       - image: "ubuntu"
         tag: "latest"
       - image: "ubuntu"

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This role has been tested on these [container images](https://hub.docker.com/u/r
 |---------|----|
 |debian|buster|
 |el|8|
-|fedora|32|
+|fedora|32, 33|
 |ubuntu|focal, bionic|
 
 The minimum version of Ansible required is 2.10, tests have been done to:
@@ -91,7 +91,6 @@ Some variarations of the build matrix do not work. These are the variations and 
 | CentOS 8 | Not supported. |
 | OpenSUSE Leap | Not supported. |
 | Ubuntu devel | Not supported. |
-| fedora:33 | The RPMs are not published at https://download.docker.com/linux/fedora |
 
 
 If you find issues, please register them in [GitHub](https://github.com/robertdebock/ansible-role-docker_ce/issues)

--- a/meta/exception.yml
+++ b/meta/exception.yml
@@ -12,5 +12,3 @@ exceptions:
     reason: Not supported.
   - variation: Ubuntu devel
     reason: Not supported.
-  - variation: fedora:33
-    reason: "The RPMs are not published at https://download.docker.com/linux/fedora"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -18,6 +18,7 @@ galaxy_info:
     - name: Fedora
       versions:
         - 32
+        - 33
     - name: Ubuntu
       versions:
         - focal


### PR DESCRIPTION
I updated `meta/main.yml` and `meta/exception.yml` and then ran `generate.yml`

---
name: Pull request
about: Docker now provides packages for Fedora 33, so I added it to `platforms` in `meta/main.yml` and removed it from `meta/exception.yml`, and then ran your `generate.yml` playbook.

---

**Describe the change**
See above. I did not actually make any changes to the role itself, just the metadata.

**Testing**
I ran `image=fedora tag=latest molecule test` and it works as expected.