### PR TITLE
Add option to assign existing users to the docker privileged user group.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,19 @@ The machine needs to be prepared. In CI this is done using `molecule/default/pre
 
 Also see a [full explanation and example](https://robertdebock.nl/how-to-use-these-roles.html) on how to use these roles.
 
+## [Role Variables](#role-variables)
+
+The default values for the variables are set in `defaults/main.yml`:
+```yaml
+---
+# defaults file for docker_ce
+
+# Add users to the privileged docker group. For example:
+# docker_ce_privileged_users:
+#  - UserA
+#  - UserB
+docker_ce_privileged_users:
+```
 
 ## [Requirements](#requirements)
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+# defaults file for docker_ce
+
+# Add users to the privileged docker group. For example:
+# docker_ce_privileged_users:
+#  - UserA
+#  - UserB
+docker_ce_privileged_users:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -6,3 +6,6 @@
 
   roles:
     - role: ansible-role-docker_ce
+      docker_ce_privileged_users:
+        - woody
+        - buzz

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -10,7 +10,13 @@
     - role: robertdebock.buildtools
     - role: robertdebock.python_pip
     - role: robertdebock.core_dependencies
-    - role: robertdebock.users
-      users_user_list:
-        - name: woody
-        - name: buzz
+
+  tasks:
+    - name: Create test case users
+      user:
+        name: "{{ user }}"
+      loop:
+        - woody
+        - buzz
+      loop_control:
+        loop_var: user

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -10,3 +10,7 @@
     - role: robertdebock.buildtools
     - role: robertdebock.python_pip
     - role: robertdebock.core_dependencies
+    - role: robertdebock.users
+      users_user_list:
+        - name: woody
+        - name: buzz

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -5,6 +5,16 @@
   gather_facts: no
 
   tasks:
+    - name: Check docker group configuration
+      lineinfile:
+        path: /etc/group
+        regex: '^docker:x:\d*:woody,buzz$'
+        state: absent
+      check_mode: yes
+      register: docker_ce_group
+      changed_when: not docker_ce_group is changed
+      failed_when: docker_ce_group is changed
+
     - name: install pip docker-py
       ansible.builtin.pip:
         name: docker-py

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,6 +36,22 @@
     name: "{{ docker_ce_packages }}"
     state: present
 
+- name: create privileged docker user group
+  ansible.builtin.group:
+    name: docker
+    state: present
+
+- name: adding existing user '{{ user }}' to group docker
+  user:
+    name: '{{ user }}'
+    groups: docker
+    append: yes
+  loop: "{{ docker_ce_privileged_users }}"
+  loop_control:
+    loop_var: user
+  when:
+    - docker_ce_privileged_users | length
+
 - name: start and enable docker_ce
   ansible.builtin.service:
     name: "{{ docker_ce_service }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,9 +41,9 @@
     name: docker
     state: present
 
-- name: adding existing user '{{ user }}' to group docker
+- name: add privileged users to the docker user group
   user:
-    name: '{{ user }}'
+    name: "{{ user }}"
     groups: docker
     append: yes
   loop: "{{ docker_ce_privileged_users }}"


### PR DESCRIPTION
Add option to assign existing users to the privileged docker user group.
---

**Description**
This PR provides the ability to assign existing users to the Docker privileged user group ([see official docs](https://docs.docker.com/engine/install/linux-postinstall/)).

**Testing**
New test case created.

@robertdebock: If you're okay with this change, I would create the same PR for the "ansible-role-docker" repository.
