### PR TITLE
migrate away from deprecated apt-key

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,14 +10,22 @@
   when:
     - ansible_pkg_mgr == "apt"
   block:
+    - name: Ensure location exists for keeping apt gpg keys
+      ansible.builtin.file:
+        path: "{{ docker_ce_apt_gpg_key_dir }}"
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
     - name: Install apt key
-      ansible.builtin.apt_key:
+      ansible.builtin.get_url:
         url: "{{ docker_ce_apt_key_url }}"
-        state: present
-
+        dest: "{{ docker_ce_apt_gpg_key_dir }}/{{ docker_ce_apt_key_file }}"
+        mode: "0644"
     - name: Install docker_ce repository for apt
       ansible.builtin.apt_repository:
         repo: "{{ docker_ce_apt_repository_repo }}"
+        filename: "{{ docker_ce_apt_repository_repo_file }}"
         state: present
       notify:
         - Apt update cache

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -18,8 +18,11 @@ _docker_ce_arch:
 
 # Debian / Ubuntu repo
 docker_ce_apt_key_url: "https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg"
+docker_ce_apt_gpg_key_dir: "/etc/apt/keyrings"
+docker_ce_apt_key_file: "docker.asc"
 docker_ce_apt_repository_arch: "{{ _docker_ce_arch[ansible_architecture] | default(_docker_ce_arch['default']) }}"
-docker_ce_apt_repository_repo: "deb [arch={{ docker_ce_apt_repository_arch }}] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
+docker_ce_apt_repository_repo: "deb [arch={{ docker_ce_apt_repository_arch }} signed-by={{ docker_ce_apt_gpg_key_dir }}/{{ docker_ce_apt_key_file }}] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
+docker_ce_apt_repository_repo_file: "/etc/apt/sources.list.d/docker"
 
 _docker_ce_dist:
   default: "{{ ansible_distribution | lower }}"


### PR DESCRIPTION
---
name: nuke apt-key from orbit
about: This migrates away from deprecated apt-key

---

In modern versions of Debian / Ubuntu, to increase security, they have deprecated the use of apt-key in favour of placing the gpg key in a directory and then the `.list` file references the gpg key used to sign packages for the repo.

**Testing**

I am currently not able to run the whole test framework on my laptop but I have applied this role to a few Ubuntu 22.04 VMs now.
I will address any issues once molecule runs in the PR.
