### PR TITLE
Back to rhel for OracleLinux

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -25,7 +25,7 @@ _docker_ce_dist:
   default: "{{ ansible_distribution | lower }}"
   Rocky: centos
   RedHat: rhel
-  OracleLinux: centos
+  OracleLinux: rhel
 
 docker_ce_dist: "{{ _docker_ce_dist[ansible_distribution] | default(_docker_ce_dist['default']) }}"
 


### PR DESCRIPTION
Docker CE looks to have stopped releasing builds for Centos at version 26.1.3, only RHEL is seeing the latest builds.

You can compare:
https://download.docker.com/linux/centos/8/x86_64/stable/Packages/ https://download.docker.com/linux/rhel/8/x86_64/stable/Packages/

I'm not sure why this may have recently been set to Centos for Oracle Linux, perhaps there are other issues around this.

**Describe the change**
Changes the variable for the Docker CE distribution to use with Oracle Linux from centos to rhel 

**Testing**
Tested on Oracle Linux 8.10 and Debian 12, both times Docker-CE installed and started although I didn't do anything much further for testing these.
